### PR TITLE
Feature require subject

### DIFF
--- a/Kernel/Modules/AdminQuickClose.pm
+++ b/Kernel/Modules/AdminQuickClose.pm
@@ -107,7 +107,7 @@ sub Run {
             $Errors{ValidIDInvalid} = 'ServerError';
         }
 
-        for my $Param (qw(Name Body)) {
+        for my $Param (qw(Name Subject Body)) {
             if ( !$GetParam{$Param} ) {
                 $Errors{ $Param . 'Invalid' } = 'ServerError';
             }

--- a/Kernel/Output/HTML/Templates/Standard/AdminQuickCloseForm.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQuickCloseForm.tt
@@ -76,8 +76,11 @@
                             [% Translate("Subject") | html %]:
                         </label>
                         <div class="Field">
-                            <input type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="W75pc Validate_Required" />
+                            <input type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="W75pc Validate_Required [% Data.SubjectInvalid | html %]" />
                             <div id="SubjectError" class="TooltipErrorMessage">
+                                <p>[% Translate("A subject for the note is required.") | html %]</p>
+                            </div>
+                            <div id="SubjectServerError" class="TooltipErrorMessage">
                                 <p>[% Translate("A subject for the note is required.") | html %]</p>
                             </div>
                         </div>

--- a/Kernel/Output/HTML/Templates/Standard/AdminQuickCloseForm.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AdminQuickCloseForm.tt
@@ -72,11 +72,14 @@
                         </div>
                         <div class="Clear"></div>
 
-                        <label for="Subject">
+                        <label for="Subject" class="Mandatory">
                             [% Translate("Subject") | html %]:
                         </label>
                         <div class="Field">
-                            <input type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="W75pc" />
+                            <input type="text" id="Subject" name="Subject" value="[% Data.Subject | html %]" class="W75pc Validate_Required" />
+                            <div id="SubjectError" class="TooltipErrorMessage">
+                                <p>[% Translate("A subject for the note is required.") | html %]</p>
+                            </div>
                         </div>
                         <div class="Clear"></div>
 


### PR DESCRIPTION
If you create & use QuickCloses with empty Subject, warnings like "[Thu Dec  3 18:56:52 2015] index.pl: Use of uninitialized value $CloseData{"Subject"} in length at /opt/otrs-5.0.4/bin/cgi-bin/../../Kernel/Modules/AgentTicketCloseBulk.pm line 107." will occur.
I personally find Notes without Subject nasty, so I'd enforce setting subjects, another option would of course be to change the code in the given line of AgentTicketCloseBulk.pm
