### PR TITLE
Fix error when using QuickClose with pending state

### DIFF
--- a/Kernel/Modules/AgentTicketCloseBulk.pm
+++ b/Kernel/Modules/AgentTicketCloseBulk.pm
@@ -249,7 +249,7 @@ sub Run {
                     ( 1 * 24 * 60 );
     
                 my ($Sec, $Min, $Hour, $Day, $Month, $Year) = $TimeObject->SystemTime2Date(
-                    SystemTime => $Self->{TimeObject}->SystemTime() + ( $Diff * 60 ),
+                    SystemTime => $TimeObject->SystemTime() + ( $Diff * 60 ),
                 );
 
                 if ( $CloseData{FixHour} ) {


### PR DESCRIPTION
Error is: Can't call method "SystemTime" on an undefined value
Fix should be obvious enough - please tell if you need more information.