### PR TITLE
removed check for EncodeInternalUser (obsoelete)

### DIFF
--- a/Kernel/Modules/AgentQuickCloseUserSearch.pm
+++ b/Kernel/Modules/AgentQuickCloseUserSearch.pm
@@ -90,16 +90,6 @@ sub Run {
             }
         }
 
-        # workaround, all auto completion requests get posted by utf8 anyway
-        # convert any to 8bit string if application is not running in utf8
-        if ( !$EncodeObject->EncodeInternalUsed() ) {
-            $Search = $EncodeObject->Convert(
-                Text => $Search,
-                From => 'utf-8',
-                To   => $LayoutObject->{UserCharset},
-            );
-        }
-
         # get user list
         my %UserList = $UserObject->UserSearch(
             Search => $Search,


### PR DESCRIPTION
Removed UTF8-decoding for non-utf8 systems. Method "EncodeInternalUsed" not included in Kernel::System::Encodein OTRS Framework 5 anymore.